### PR TITLE
Use express ~3.x

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/arcturus/firefox-os-simplepush.git"
   },
   "dependencies" : {
-    "express": "*",
+    "express": "~3.x",
     "mongoq": "*",
     "request": "*"
   },


### PR DESCRIPTION
Minor change: firefox-os-simplepush only works with express 3.x, so you must fix that version in your package.json. Otherwise "npm install" uses express 4.x and the server doesn't even start.